### PR TITLE
Improve runtime stability validation baseline

### DIFF
--- a/Assets/vFrame.Core.Tests.meta
+++ b/Assets/vFrame.Core.Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4044c469055fe3b49b913eee9646da4f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/vFrame.Core.Tests/EditMode.meta
+++ b/Assets/vFrame.Core.Tests/EditMode.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ade4866ad64022b4096342f6c63e0a7d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/vFrame.Core.Tests/EditMode/Asynchronous.meta
+++ b/Assets/vFrame.Core.Tests/EditMode/Asynchronous.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6b7f99c896081554db8744b137bac60e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/vFrame.Core.Tests/EditMode/Asynchronous/AsyncRequestCtrlTests.cs
+++ b/Assets/vFrame.Core.Tests/EditMode/Asynchronous/AsyncRequestCtrlTests.cs
@@ -1,0 +1,94 @@
+using NUnit.Framework;
+using vFrame.Core.Unity.Asynchronous;
+
+namespace vFrame.Core.Tests.EditMode.Asynchronous
+{
+    public class AsyncRequestCtrlTests
+    {
+        [Test]
+        public void Update_WhenRequestFinished_InvokesOnlyOnRequestFinish() {
+            var ctrl = new AsyncRequestCtrl();
+            ctrl.Create();
+
+            try {
+                var request = new TestAsyncRequest();
+                request.Create();
+                request.MarkFinished();
+
+                var finishCount = 0;
+                var errorCount = 0;
+                IAsyncRequest finishedRequest = null;
+
+                ctrl.OnRequestFinish += current => {
+                    finishCount++;
+                    finishedRequest = current;
+                };
+                ctrl.OnRequestError += _ => errorCount++;
+
+                ctrl.AddRequest(request);
+                ctrl.Update();
+
+                Assert.That(finishCount, Is.EqualTo(1));
+                Assert.That(errorCount, Is.EqualTo(0));
+                Assert.That(finishedRequest, Is.SameAs(request));
+            }
+            finally {
+                ctrl.Destroy();
+            }
+        }
+
+        [Test]
+        public void Update_WhenRequestErrored_InvokesOnlyOnRequestError() {
+            var ctrl = new AsyncRequestCtrl();
+            ctrl.Create();
+
+            try {
+                var request = new TestAsyncRequest();
+                request.Create();
+                request.MarkErrored();
+
+                var finishCount = 0;
+                var errorCount = 0;
+                IAsyncRequest erroredRequest = null;
+
+                ctrl.OnRequestFinish += _ => finishCount++;
+                ctrl.OnRequestError += current => {
+                    errorCount++;
+                    erroredRequest = current;
+                };
+
+                ctrl.AddRequest(request);
+                ctrl.Update();
+
+                Assert.That(finishCount, Is.EqualTo(0));
+                Assert.That(errorCount, Is.EqualTo(1));
+                Assert.That(erroredRequest, Is.SameAs(request));
+            }
+            finally {
+                ctrl.Destroy();
+            }
+        }
+
+        private class TestAsyncRequest : AsyncRequest
+        {
+            public override float Progress => 0f;
+
+            public void MarkFinished() {
+                Finish();
+            }
+
+            public void MarkErrored() {
+                Abort();
+            }
+
+            protected override void OnStart() {
+            }
+
+            protected override void OnStop() {
+            }
+
+            protected override void OnUpdate() {
+            }
+        }
+    }
+}

--- a/Assets/vFrame.Core.Tests/EditMode/Asynchronous/AsyncRequestCtrlTests.cs.meta
+++ b/Assets/vFrame.Core.Tests/EditMode/Asynchronous/AsyncRequestCtrlTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6ebfa0a81905ab04fabeb91de17fb22f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/vFrame.Core.Tests/EditMode/Base.meta
+++ b/Assets/vFrame.Core.Tests/EditMode/Base.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 34cf4dcb273ca534cacce904ebad40c3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/vFrame.Core.Tests/EditMode/Base/BaseObjectCreateTests.cs
+++ b/Assets/vFrame.Core.Tests/EditMode/Base/BaseObjectCreateTests.cs
@@ -1,0 +1,141 @@
+using System;
+using NUnit.Framework;
+using vFrame.Core.Base;
+
+namespace vFrame.Core.Tests.EditMode.Base
+{
+    public class BaseObjectCreateTests
+    {
+        [Test]
+        public void Create_SetsCreatedState_WhenOnCreateSucceeds() {
+            var sut = new SuccessfulBaseObject();
+
+            Assert.That(sut.Created, Is.False);
+            Assert.That(sut.Destroyed, Is.False);
+            Assert.Throws<BaseObjectNotCreatedException>(() => sut.AssertCreated());
+
+            sut.Create();
+
+            Assert.That(sut.OnCreateCallCount, Is.EqualTo(1));
+            Assert.That(sut.Created, Is.True);
+            Assert.That(sut.Destroyed, Is.False);
+            Assert.DoesNotThrow(() => sut.AssertCreated());
+        }
+
+        [Test]
+        public void Create_KeepsUncreatedState_WhenOnCreateThrows() {
+            var sut = new ThrowingBaseObject();
+
+            var exception = Assert.Throws<InvalidOperationException>(() => sut.Create());
+
+            Assert.That(exception.Message, Is.EqualTo(ThrowingBaseObject.ErrorMessage));
+            Assert.That(sut.OnCreateCallCount, Is.EqualTo(1));
+            Assert.That(sut.Created, Is.False);
+            Assert.That(sut.Destroyed, Is.False);
+            Assert.Throws<BaseObjectNotCreatedException>(() => sut.AssertCreated());
+        }
+
+        [Test]
+        public void GenericCreate_SetsCreatedStateAndForwardsArgument_WhenOnCreateSucceeds() {
+            var sut = new SuccessfulGenericBaseObject();
+
+            Assert.That(sut.Created, Is.False);
+            Assert.That(sut.Destroyed, Is.False);
+            Assert.Throws<BaseObjectNotCreatedException>(() => sut.AssertCreated());
+
+            sut.Create(123);
+
+            Assert.That(sut.OnCreateCallCount, Is.EqualTo(1));
+            Assert.That(sut.LastValue, Is.EqualTo(123));
+            Assert.That(sut.Created, Is.True);
+            Assert.That(sut.Destroyed, Is.False);
+            Assert.DoesNotThrow(() => sut.AssertCreated());
+        }
+
+        [Test]
+        public void GenericCreate_KeepsUncreatedState_WhenOnCreateThrows() {
+            var sut = new ThrowingGenericBaseObject();
+
+            var exception = Assert.Throws<InvalidOperationException>(() => sut.Create(123));
+
+            Assert.That(exception.Message, Is.EqualTo(ThrowingGenericBaseObject.ErrorMessage));
+            Assert.That(sut.OnCreateCallCount, Is.EqualTo(1));
+            Assert.That(sut.ReceivedValue, Is.EqualTo(123));
+            Assert.That(sut.Created, Is.False);
+            Assert.That(sut.Destroyed, Is.False);
+            Assert.Throws<BaseObjectNotCreatedException>(() => sut.AssertCreated());
+        }
+
+        private sealed class SuccessfulBaseObject : BaseObject
+        {
+            public int OnCreateCallCount { get; private set; }
+
+            public void AssertCreated() {
+                ThrowIfNotCreated();
+            }
+
+            protected override void OnCreate() {
+                OnCreateCallCount++;
+            }
+
+            protected override void OnDestroy() { }
+        }
+
+        private sealed class ThrowingBaseObject : BaseObject
+        {
+            public const string ErrorMessage = "OnCreate failed.";
+
+            public int OnCreateCallCount { get; private set; }
+
+            public void AssertCreated() {
+                ThrowIfNotCreated();
+            }
+
+            protected override void OnCreate() {
+                OnCreateCallCount++;
+                throw new InvalidOperationException(ErrorMessage);
+            }
+
+            protected override void OnDestroy() { }
+        }
+
+        private sealed class SuccessfulGenericBaseObject : BaseObject<int>
+        {
+            public int OnCreateCallCount { get; private set; }
+
+            public int LastValue { get; private set; }
+
+            public void AssertCreated() {
+                ThrowIfNotCreated();
+            }
+
+            protected override void OnCreate(int arg1) {
+                OnCreateCallCount++;
+                LastValue = arg1;
+            }
+
+            protected override void OnDestroy() { }
+        }
+
+        private sealed class ThrowingGenericBaseObject : BaseObject<int>
+        {
+            public const string ErrorMessage = "Generic OnCreate failed.";
+
+            public int OnCreateCallCount { get; private set; }
+
+            public int ReceivedValue { get; private set; }
+
+            public void AssertCreated() {
+                ThrowIfNotCreated();
+            }
+
+            protected override void OnCreate(int arg1) {
+                OnCreateCallCount++;
+                ReceivedValue = arg1;
+                throw new InvalidOperationException(ErrorMessage);
+            }
+
+            protected override void OnDestroy() { }
+        }
+    }
+}

--- a/Assets/vFrame.Core.Tests/EditMode/Base/BaseObjectCreateTests.cs.meta
+++ b/Assets/vFrame.Core.Tests/EditMode/Base/BaseObjectCreateTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 04f3bedba5d15c14887b1b5eab56e3a9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/vFrame.Core.Tests/EditMode/Coroutine.meta
+++ b/Assets/vFrame.Core.Tests/EditMode/Coroutine.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 226f9aa1b3b1f0243a6803d65171c2de
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/vFrame.Core.Tests/EditMode/ThreadedTaskFaultTerminationTests.cs
+++ b/Assets/vFrame.Core.Tests/EditMode/ThreadedTaskFaultTerminationTests.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using NUnit.Framework;
+using vFrame.Core.MultiThreading;
+
+namespace vFrame.Core.Tests.EditMode
+{
+    public class ThreadedTaskFaultTerminationTests
+    {
+        [Test]
+        public void FaultedWorker_EventuallyReachesDoneState() {
+            var task = new ThrowingThreadedTask();
+
+            task.Create(1);
+
+            var timeout = Stopwatch.StartNew();
+            while (!task.IsDone && timeout.Elapsed < TimeSpan.FromSeconds(1)) {
+                Thread.Sleep(10);
+            }
+
+            Assert.That(task.IsDone, Is.True, "Faulted threaded task should eventually become done.");
+            Assert.That(task.Progress, Is.EqualTo(1f), "Faulted threaded task should report terminal progress.");
+            Assert.That(task.CapturedException, Is.TypeOf<InvalidOperationException>());
+        }
+
+        private sealed class ThrowingThreadedTask : ThreadedTask<int>
+        {
+            public Exception CapturedException { get; private set; }
+
+            protected override void ErrorHandler(Exception e) {
+                CapturedException = e;
+            }
+
+            protected override void OnHandleTask(int arg) {
+                throw new InvalidOperationException("Expected test failure.");
+            }
+        }
+    }
+}

--- a/Assets/vFrame.Core.Tests/EditMode/ThreadedTaskFaultTerminationTests.cs.meta
+++ b/Assets/vFrame.Core.Tests/EditMode/ThreadedTaskFaultTerminationTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2625b97d108ea0d45a2217d97ed1ec9c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/vFrame.Core.Tests/EditMode/vFrame.Core.Tests.EditMode.asmdef
+++ b/Assets/vFrame.Core.Tests/EditMode/vFrame.Core.Tests.EditMode.asmdef
@@ -1,0 +1,19 @@
+{
+    "name": "vFrame.Core.Tests.EditMode",
+    "references": [
+        "vFrame.Core",
+        "vFrame.Core.Unity"
+    ],
+    "optionalUnityReferences": [
+        "TestAssemblies"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": []
+}

--- a/Assets/vFrame.Core.Tests/EditMode/vFrame.Core.Tests.EditMode.asmdef.meta
+++ b/Assets/vFrame.Core.Tests/EditMode/vFrame.Core.Tests.EditMode.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 25f2ae1c9d8aaf8499d660e72e0ed343
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/vFrame.Core.Tests/PlayMode.meta
+++ b/Assets/vFrame.Core.Tests/PlayMode.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fc65ced15ba2fd14383fe5d5fded1775
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/vFrame.Core.Tests/PlayMode/Coroutine.meta
+++ b/Assets/vFrame.Core.Tests/PlayMode/Coroutine.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 19208b10d0c5d044dbe89ab5df22a135
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/vFrame.Core.Tests/PlayMode/Coroutine/CoroutinePoolCancellationTests.cs
+++ b/Assets/vFrame.Core.Tests/PlayMode/Coroutine/CoroutinePoolCancellationTests.cs
@@ -1,0 +1,30 @@
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine.TestTools;
+using vFrame.Core.Unity.Coroutine;
+
+namespace vFrame.Core.Tests.PlayMode.Coroutine
+{
+    public class CoroutinePoolCancellationTests
+    {
+        [UnityTest]
+        public IEnumerator StopCoroutine_WhenTaskIsWaiting_DoesNotThrow() {
+            var pool = new CoroutinePool("TestPool", 0);
+
+            try {
+                var handle = pool.StartCoroutine(DummyTask());
+
+                Assert.DoesNotThrow(() => pool.StopCoroutine(handle));
+            }
+            finally {
+                pool.Destroy();
+            }
+
+            yield return null;
+        }
+
+        private static IEnumerator DummyTask() {
+            yield return null;
+        }
+    }
+}

--- a/Assets/vFrame.Core.Tests/PlayMode/Coroutine/CoroutinePoolCancellationTests.cs.meta
+++ b/Assets/vFrame.Core.Tests/PlayMode/Coroutine/CoroutinePoolCancellationTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0f32b29c2e150f34596b37daac47da7e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/vFrame.Core.Tests/PlayMode/vFrame.Core.Tests.PlayMode.asmdef
+++ b/Assets/vFrame.Core.Tests/PlayMode/vFrame.Core.Tests.PlayMode.asmdef
@@ -1,0 +1,19 @@
+{
+    "name": "vFrame.Core.Tests.PlayMode",
+    "references": [
+        "vFrame.Core",
+        "vFrame.Core.Unity"
+    ],
+    "optionalUnityReferences": [
+        "TestAssemblies"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [
+        "Editor"
+    ],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": []
+}

--- a/Assets/vFrame.Core.Tests/PlayMode/vFrame.Core.Tests.PlayMode.asmdef.meta
+++ b/Assets/vFrame.Core.Tests/PlayMode/vFrame.Core.Tests.PlayMode.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0fcb9509f35703e42b051d864c41ecf8
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/vFrame.Core.Unity/Runtime/Asynchronous/AsyncRequestCtrl.cs
+++ b/Assets/vFrame.Core.Unity/Runtime/Asynchronous/AsyncRequestCtrl.cs
@@ -79,11 +79,11 @@ namespace vFrame.Core.Unity.Asynchronous
                         break;
                     case AsyncState.Finished:
                         _requests.RemoveAt(i);
-                        OnRequestError?.Invoke(request);
+                        OnRequestFinish?.Invoke(request);
                         break;
                     case AsyncState.Error:
                         _requests.RemoveAt(i);
-                        OnRequestFinish?.Invoke(request);
+                        OnRequestError?.Invoke(request);
                         break;
                 }
             }

--- a/Assets/vFrame.Core.Unity/Runtime/Coroutine/CoroutinePool.cs
+++ b/Assets/vFrame.Core.Unity/Runtime/Coroutine/CoroutinePool.cs
@@ -95,11 +95,11 @@ namespace vFrame.Core.Unity.Coroutine
         public void StopCoroutine(int handle) {
             Debug.Log("CoroutinePool:StopCoroutine - Stopping coroutine: " + handle);
             // Remove from waiting list
-            foreach (var context in TasksWaiting) {
-                if (context.Handle != handle) {
+            for (var i = 0; i < TasksWaiting.Count; ++i) {
+                if (TasksWaiting[i].Handle != handle) {
                     continue;
                 }
-                TasksWaiting.Remove(context);
+                TasksWaiting.RemoveAt(i);
                 Debug.Log("CoroutinePool:StopCoroutine - Stopping coroutine, remove from waiting list: " + handle);
                 break;
             }

--- a/Assets/vFrame.Core/Runtime/Base/BaseObject.cs
+++ b/Assets/vFrame.Core/Runtime/Base/BaseObject.cs
@@ -63,13 +63,10 @@ namespace vFrame.Core.Base
             if (Created) {
                 return;
             }
-            try {
-                OnCreate();
-            }
-            finally {
-                Created = true;
-                Destroyed = false;
-            }
+
+            OnCreate();
+            Created = true;
+            Destroyed = false;
         }
 
         protected abstract void OnCreate();
@@ -78,13 +75,9 @@ namespace vFrame.Core.Base
     public abstract class BaseObject<T1> : Object, IBaseObject<T1>
     {
         public void Create(T1 arg1) {
-            try {
-                OnCreate(arg1);
-            }
-            finally {
-                Created = true;
-                Destroyed = false;
-            }
+            OnCreate(arg1);
+            Created = true;
+            Destroyed = false;
         }
 
         protected abstract void OnCreate(T1 arg1);
@@ -93,13 +86,9 @@ namespace vFrame.Core.Base
     public abstract class BaseObject<T1, T2> : Object, IBaseObject<T1, T2>
     {
         public void Create(T1 arg1, T2 arg2) {
-            try {
-                OnCreate(arg1, arg2);
-            }
-            finally {
-                Created = true;
-                Destroyed = false;
-            }
+            OnCreate(arg1, arg2);
+            Created = true;
+            Destroyed = false;
         }
 
         protected abstract void OnCreate(T1 arg1, T2 arg2);
@@ -108,13 +97,9 @@ namespace vFrame.Core.Base
     public abstract class BaseObject<T1, T2, T3> : Object, IBaseObject<T1, T2, T3>
     {
         public void Create(T1 arg1, T2 arg2, T3 arg3) {
-            try {
-                OnCreate(arg1, arg2, arg3);
-            }
-            finally {
-                Created = true;
-                Destroyed = false;
-            }
+            OnCreate(arg1, arg2, arg3);
+            Created = true;
+            Destroyed = false;
         }
 
         protected abstract void OnCreate(T1 arg1, T2 arg2, T3 arg3);
@@ -123,13 +108,9 @@ namespace vFrame.Core.Base
     public abstract class BaseObject<T1, T2, T3, T4> : Object, IBaseObject<T1, T2, T3, T4>
     {
         public void Create(T1 arg1, T2 arg2, T3 arg3, T4 arg4) {
-            try {
-                OnCreate(arg1, arg2, arg3, arg4);
-            }
-            finally {
-                Created = true;
-                Destroyed = false;
-            }
+            OnCreate(arg1, arg2, arg3, arg4);
+            Created = true;
+            Destroyed = false;
         }
 
         protected abstract void OnCreate(T1 arg1, T2 arg2, T3 arg3, T4 arg4);
@@ -138,13 +119,9 @@ namespace vFrame.Core.Base
     public abstract class BaseObject<T1, T2, T3, T4, T5> : Object, IBaseObject<T1, T2, T3, T4, T5>
     {
         public void Create(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) {
-            try {
-                OnCreate(arg1, arg2, arg3, arg4, arg5);
-            }
-            finally {
-                Created = true;
-                Destroyed = false;
-            }
+            OnCreate(arg1, arg2, arg3, arg4, arg5);
+            Created = true;
+            Destroyed = false;
         }
 
         protected abstract void OnCreate(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5);

--- a/Assets/vFrame.Core/Runtime/MultiThreading/ThreadedTask.cs
+++ b/Assets/vFrame.Core/Runtime/MultiThreading/ThreadedTask.cs
@@ -32,7 +32,6 @@ namespace vFrame.Core.MultiThreading
             }
             catch (Exception e) {
                 ErrorHandler(e);
-                return;
             }
 
             lock (_lockObject) {
@@ -75,7 +74,6 @@ namespace vFrame.Core.MultiThreading
             }
             catch (Exception e) {
                 ErrorHandler(e);
-                return;
             }
 
             lock (_lockObject) {

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,6 +1,8 @@
 {
   "dependencies": {
-    "com.unity.ide.rider": "3.0.25",
+    "com.unity.ai.navigation": "1.1.6",
+    "com.unity.ide.rider": "3.0.36",
+    "com.unity.test-framework": "1.1.33",
     "com.unity.ugui": "1.0.0",
     "com.unity.modules.animation": "1.0.0",
     "com.unity.modules.assetbundle": "1.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,0 +1,180 @@
+{
+  "dependencies": {
+    "com.unity.ai.navigation": {
+      "version": "1.1.6",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.modules.ai": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.ext.nunit": {
+      "version": "1.0.6",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.ide.rider": {
+      "version": "3.0.36",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.ext.nunit": "1.0.6"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.test-framework": {
+      "version": "1.1.33",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.ext.nunit": "1.0.6",
+        "com.unity.modules.imgui": "1.0.0",
+        "com.unity.modules.jsonserialize": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.ugui": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.ui": "1.0.0",
+        "com.unity.modules.imgui": "1.0.0"
+      }
+    },
+    "com.unity.modules.ai": {
+      "version": "1.0.0",
+      "depth": 1,
+      "source": "builtin",
+      "dependencies": {}
+    },
+    "com.unity.modules.animation": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {}
+    },
+    "com.unity.modules.assetbundle": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {}
+    },
+    "com.unity.modules.audio": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {}
+    },
+    "com.unity.modules.imageconversion": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {}
+    },
+    "com.unity.modules.imgui": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {}
+    },
+    "com.unity.modules.jsonserialize": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {}
+    },
+    "com.unity.modules.particlesystem": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {}
+    },
+    "com.unity.modules.physics": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {}
+    },
+    "com.unity.modules.physics2d": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {}
+    },
+    "com.unity.modules.ui": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {}
+    },
+    "com.unity.modules.uielements": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.ui": "1.0.0",
+        "com.unity.modules.imgui": "1.0.0",
+        "com.unity.modules.jsonserialize": "1.0.0"
+      }
+    },
+    "com.unity.modules.unityanalytics": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.unitywebrequest": "1.0.0",
+        "com.unity.modules.jsonserialize": "1.0.0"
+      }
+    },
+    "com.unity.modules.unitywebrequest": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {}
+    },
+    "com.unity.modules.unitywebrequestassetbundle": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.assetbundle": "1.0.0",
+        "com.unity.modules.unitywebrequest": "1.0.0"
+      }
+    },
+    "com.unity.modules.unitywebrequestaudio": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.unitywebrequest": "1.0.0",
+        "com.unity.modules.audio": "1.0.0"
+      }
+    },
+    "com.unity.modules.unitywebrequesttexture": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.unitywebrequest": "1.0.0",
+        "com.unity.modules.imageconversion": "1.0.0"
+      }
+    },
+    "com.unity.modules.unitywebrequestwww": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.unitywebrequest": "1.0.0",
+        "com.unity.modules.unitywebrequestassetbundle": "1.0.0",
+        "com.unity.modules.unitywebrequestaudio": "1.0.0",
+        "com.unity.modules.audio": "1.0.0",
+        "com.unity.modules.assetbundle": "1.0.0",
+        "com.unity.modules.imageconversion": "1.0.0"
+      }
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Package 内包含的组件有：
 
 核心组件基本对象类型：`BaseObject`，限定统一的对象**创建**以及**销毁**流程。组件库内绝大部分组件均派生于该基础类型。
 
+`Create(...)` 只有在对应的 `OnCreate(...)` 成功执行完成后，实例才会进入已创建状态；如果初始化过程中抛出异常，则对象会保持未创建状态。
+
 `IBaseObject` 继承于接口 `ICreatable` 以及 `IDestroyable`，提供了多种泛型用于指定不同参数个数或类型的创建流程
 ```csharp
 public interface IBaseObject : ICreatable, IDestroyable { }
@@ -223,7 +225,7 @@ public interface IEventDispatcher
   使用者可继承`Task<TArg>`模板类型，实现`RunTask`接口
 
 
-* `ThreadedTask` 为在子线程中执行任务的模板类，使用时继承并实现`OnHandleTask`方法即可
+* `ThreadedTask` 为在子线程中执行任务的模板类，使用时继承并实现`OnHandleTask`方法即可。任务执行过程中如果发生异常，任务仍会进入终止状态，避免等待方无限阻塞。
   ```csharp
   public abstract class ThreadedTask<TArg> : Task<TArg>
   {
@@ -320,7 +322,7 @@ public class CoroutinePool
 }
 ```
 
-在协程池的构造函数中，提供一个参数`capacity`用于控制同时执行的协程上限，超过上限的任务会进入排队状态，直到有空闲的协程才会从队列中取出并执行
+在协程池的构造函数中，提供一个参数`capacity`用于控制同时执行的协程上限，超过上限的任务会进入排队状态，直到有空闲的协程才会从队列中取出并执行。对于仍处于排队状态的任务，可安全调用`StopCoroutine(handle)`取消等待中的任务。
 
 ### 游戏物件池（ SpawnPools ）
 

--- a/openspec/changes/archive/2026-04-03-improve-runtime-stability/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-03-improve-runtime-stability/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-02

--- a/openspec/changes/archive/2026-04-03-improve-runtime-stability/design.md
+++ b/openspec/changes/archive/2026-04-03-improve-runtime-stability/design.md
@@ -1,0 +1,76 @@
+## Context
+
+`vFrame.Core` and `vFrame.Core.Unity` provide shared runtime infrastructure used across lifecycle management, async execution, coroutine orchestration, pooling, downloads, and patching. The current implementation is broadly functional, but several foundational code paths have weak or incorrect state transitions, including object creation success tracking, async completion signaling, coroutine queue mutation, and threaded task failure behavior.
+
+This change is cross-cutting because the affected code sits at the bottom of the library stack. A defect in these areas can propagate to many higher-level systems, and the current repository has no checked-in tests to lock expected behavior. The design therefore focuses on tightening runtime contracts for a narrow set of clearly incorrect behaviors while preserving existing public API shape wherever practical.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make lifecycle and async state transitions internally consistent and predictable for `BaseObject`, `AsyncRequestCtrl`, `ThreadedTask`, and `CoroutinePool`.
+- Correct known behavior mismatches in foundational runtime systems without introducing broad API churn.
+- Establish a small but meaningful automated test baseline around the highest-risk runtime contracts in scope.
+- Improve confidence in shared infrastructure so later refactors can build on a safer base.
+
+**Non-Goals:**
+- Redesign the entire async model across the repository.
+- Replace reflection-based container messaging with a new architecture in this change.
+- Refactor `ParallelTaskRunner`, `ObjectPool`, `EventDispatcher`, or patch hash validation as part of this change.
+- Introduce new external dependencies or major package-level compatibility changes.
+
+## Decisions
+
+### Fix correctness before broad refactoring
+The first priority is to correct behavior that is clearly wrong rather than redesigning multiple subsystems at once. This keeps scope small and reduces the chance that a reliability improvement unintentionally becomes an architectural rewrite.
+
+Alternative considered:
+- Perform a larger unification of async/task abstractions now.
+Why not chosen:
+- It would increase scope and make it harder to isolate regressions in a repository with no existing test baseline.
+
+### Preserve public API shape where possible, tighten runtime semantics underneath
+The change should prefer compatible behavior fixes over signature changes. Existing APIs such as `BaseObject.Create`, `AsyncRequestCtrl`, and `ThreadedTask` remain recognizable, but their state guarantees become stricter and more internally coherent.
+
+Alternative considered:
+- Add new replacement APIs and deprecate current ones immediately.
+Why not chosen:
+- That would expand the change into a migration project rather than a focused reliability improvement.
+
+### Define reliability through observable behavioral requirements
+The change will codify behavior in OpenSpec around creation success, request completion/error dispatch, task termination on failure, and safe coroutine queue mutation. This lets the implementation and tests align to a stable contract rather than ad hoc fixes.
+
+Alternative considered:
+- Treat these as implementation details only and skip spec-level requirements.
+Why not chosen:
+- The problems are behavioral, externally observable, and foundational enough to deserve explicit requirements.
+
+### Add focused tests only for the highest-risk infrastructure contracts
+The initial test scope should cover the failure-prone paths most likely to regress: lifecycle creation failure, async finish/error routing, threaded task fault completion, and queue-safe coroutine cancellation.
+
+Alternative considered:
+- Delay tests until after code fixes land.
+Why not chosen:
+- The repository currently lacks guardrails, so reliability work without tests would leave the same class of regressions likely to return.
+
+## Risks / Trade-offs
+
+- [Behavioral tightening may expose latent caller assumptions] -> Keep public APIs stable, document changed semantics, and target only clearly invalid prior behavior.
+- [Cross-cutting fixes can create regressions in dependent systems] -> Add focused tests around each corrected runtime contract before or alongside implementation.
+- [Some modules have no existing test harness] -> Start with the smallest viable Unity test assemblies and prioritize deterministic EditMode coverage.
+- [Scope could expand into a full architecture cleanup] -> Keep this change limited to the four explicitly targeted subsystems and defer broader runtime improvements to follow-up changes.
+
+## Migration Plan
+
+This change is intended to be source-compatible for most consumers. Migration consists primarily of adopting stricter runtime expectations:
+
+1. Correct internal implementations to match the new reliability contract.
+2. Add tests that prove the corrected behavior.
+3. Validate the Unity project compiles cleanly after the changes.
+4. Update documentation where current wording implies behavior that is no longer accurate or was previously incorrect.
+
+Rollback strategy:
+- If a reliability fix unexpectedly breaks a consumer workflow, revert the specific behavioral correction rather than the full change set, then narrow the requirement or add a compatibility note before retrying.
+
+## Open Questions
+
+- Should `ThreadedTask` failure be represented only as a terminal non-blocking state for this change, with richer fault metadata deferred to a later async-contract cleanup?

--- a/openspec/changes/archive/2026-04-03-improve-runtime-stability/proposal.md
+++ b/openspec/changes/archive/2026-04-03-improve-runtime-stability/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+The repository already provides a broad set of runtime infrastructure for lifecycle management, async requests, pooling, event dispatch, downloads, and patching, but several core paths have correctness and maintainability risks. A small number of state-handling bugs and unclear runtime contracts reduce trust in the library and make future improvements riskier than they need to be.
+
+## What Changes
+
+- Fix core runtime state and lifecycle inconsistencies in foundational infrastructure such as object creation, async request completion, coroutine stopping, and threaded task failure handling.
+- Define a narrow runtime reliability contract around these corrected behaviors so implementation and tests align to the same expectations.
+- Add focused test coverage for the highest-risk lifecycle and state-machine behaviors so regressions are caught earlier.
+- Clarify runtime behavior for these corrected paths without expanding this change into broader pooling, dispatcher, patching, or async architecture refactors.
+
+## Capabilities
+
+### New Capabilities
+- `runtime-reliability`: Defines behavioral guarantees for lifecycle, async completion, task failure, pooling, and dispatcher correctness in the runtime infrastructure.
+
+### Modified Capabilities
+
+## Impact
+
+- Affected code is primarily under `Assets/vFrame.Core/Runtime` and `Assets/vFrame.Core.Unity/Runtime`.
+- The most impacted subsystems are `BaseObject`, `AsyncRequestCtrl`, `ThreadedTask`, and `CoroutinePool`.
+- Public APIs should remain largely stable, but runtime behavior will become stricter and more predictable in edge cases and failure paths.
+- This change is intended to establish a safer baseline for later, separate improvements to pooling, dispatching, patching, and async abstractions.

--- a/openspec/changes/archive/2026-04-03-improve-runtime-stability/specs/runtime-reliability/spec.md
+++ b/openspec/changes/archive/2026-04-03-improve-runtime-stability/specs/runtime-reliability/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: Base object creation SHALL only succeed after successful initialization
+Runtime base objects MUST report themselves as created only after `OnCreate(...)` completes successfully. If initialization throws an exception, the object MUST NOT transition into a created state.
+
+#### Scenario: Create fails during initialization
+- **WHEN** a `BaseObject`-derived type throws from `OnCreate(...)`
+- **THEN** the instance MUST remain not created
+
+#### Scenario: Create succeeds during initialization
+- **WHEN** a `BaseObject`-derived type completes `OnCreate(...)` without error
+- **THEN** the instance MUST transition into a created state
+
+### Requirement: Async request controller SHALL route terminal events correctly
+The async request controller MUST dispatch finish notifications only for successfully finished requests and MUST dispatch error notifications only for faulted requests.
+
+#### Scenario: Request finishes successfully
+- **WHEN** an async request enters the `Finished` terminal state
+- **THEN** the controller MUST raise the finish event and MUST NOT raise the error event for that request
+
+#### Scenario: Request fails with error
+- **WHEN** an async request enters the `Error` terminal state
+- **THEN** the controller MUST raise the error event and MUST NOT raise the finish event for that request
+
+### Requirement: Threaded tasks SHALL terminate on failure
+Threaded tasks MUST enter a non-blocking terminal state when task execution throws an exception so callers do not wait indefinitely for completion.
+
+#### Scenario: Background task throws during execution
+- **WHEN** a threaded task throws while handling work on a worker thread
+- **THEN** the task MUST become terminal instead of remaining indefinitely in progress
+
+#### Scenario: Waiting code observes task termination after failure
+- **WHEN** calling code waits on a threaded task that has failed during worker execution
+- **THEN** the waiting code MUST be able to observe that the task will not continue running indefinitely
+
+### Requirement: Coroutine queue mutation SHALL be safe during cancellation
+Coroutine pool cancellation MUST safely remove queued tasks without relying on collection mutation patterns that can invalidate enumeration.
+
+#### Scenario: Cancel waiting coroutine
+- **WHEN** a coroutine handle is cancelled while still waiting in the queue
+- **THEN** the coroutine MUST be removed without triggering collection-enumeration errors

--- a/openspec/changes/archive/2026-04-03-improve-runtime-stability/tasks.md
+++ b/openspec/changes/archive/2026-04-03-improve-runtime-stability/tasks.md
@@ -1,0 +1,21 @@
+## 1. Correct core lifecycle and async correctness bugs
+
+- [x] 1.1 Update `BaseObject` create flows so created state is only set after successful `OnCreate(...)` completion across all overloads
+- [x] 1.2 Fix `AsyncRequestCtrl` so finished requests trigger finish events and errored requests trigger error events
+- [x] 1.3 Update `ThreadedTask` terminal behavior so thrown worker exceptions do not leave tasks indefinitely in progress
+- [x] 1.4 Fix `CoroutinePool` queued cancellation logic to remove waiting tasks safely without mutating collections during enumeration
+
+## 2. Add regression coverage for corrected runtime contracts
+
+- [x] 2.1 Create a Unity test assembly for core runtime reliability tests if one does not already exist
+- [x] 2.2 Add tests covering failed and successful `BaseObject` creation state transitions
+- [x] 2.3 Add tests covering `AsyncRequestCtrl` finish and error event routing
+- [x] 2.4 Add tests covering `ThreadedTask` fault termination behavior
+- [x] 2.5 Add tests covering safe cancellation of queued coroutine tasks
+
+## 3. Validate and document the new reliability baseline
+
+- [x] 3.1 Run the narrowest relevant Unity test command(s) for the new reliability coverage and fix any failures
+  Validation result: batch-mode EditMode tests execute and pass in the available local Unity 2022 environment, producing `TestResults/editmode-results.xml` with 7 passing tests. The `CoroutinePool` cancellation test was moved to PlayMode because `DontDestroyOnLoad` is not valid in EditMode. Batch-mode PlayMode execution in the available local environment still reports `No tests were executed` for the PlayMode assembly, so PlayMode verification remains a follow-up validation item for the target Unity version and/or editor test runner rather than a blocker for this change.
+- [x] 3.2 Run Unity batch-mode compilation to confirm the project still compiles after the reliability fixes
+- [x] 3.3 Update repository documentation where current wording conflicts with the corrected runtime behavior or supported expectations


### PR DESCRIPTION
## Summary
- fix runtime lifecycle and async correctness issues in BaseObject, AsyncRequestCtrl, CoroutinePool, and ThreadedTask
- add EditMode and PlayMode regression test coverage plus Unity Test Framework setup for the new reliability baseline
- document the updated behavior in README.md and archive the completed OpenSpec change

## Validation
- Unity batch compilation passed with C:\Program Files\Unity\Hub\Editor\2022.3.62f3\Editor\Unity.exe
- EditMode tests passed and produced TestResults/editmode-results.xml with 7 passing tests
- the CoroutinePool cancellation test was moved to PlayMode because it depends on DontDestroyOnLoad
- batch-mode PlayMode execution in the available local environment still reported No tests were executed for the PlayMode assembly; this follow-up validation note is captured in the archived OpenSpec tasks